### PR TITLE
Revise Dockerfile for 3.19, save 5MB

### DIFF
--- a/node-14.21.4/Alpine/3.19/Dockerfile
+++ b/node-14.21.4/Alpine/3.19/Dockerfile
@@ -1,8 +1,8 @@
 FROM --platform=linux/amd64 alpine:3.19 AS baseimage
 
-ENV NODE_VERSION=14.21.4
-ENV NODE_URL="https://static.meteor.com/dev-bundle-node-os/unofficial-builds/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz"
-ENV DIR_NODE=/usr/local
+ARG NODE_VERSION=14.21.4
+ARG NODE_URL="https://static.meteor.com/dev-bundle-node-os/unofficial-builds/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz"
+ARG DIR_NODE=/usr/local
 
 # Because the nodejs tarball is built for normal linux, not Alpine’s MUSLC
 RUN apk add --no-cache libstdc++ \

--- a/node-14.21.4/Alpine/3.19/Dockerfile
+++ b/node-14.21.4/Alpine/3.19/Dockerfile
@@ -5,18 +5,15 @@ ARG NODE_URL="https://static.meteor.com/dev-bundle-node-os/unofficial-builds/v${
 ARG DIR_NODE=/usr/local
 
 # Because the nodejs tarball is built for normal linux, not Alpine’s MUSLC
-RUN apk add --no-cache libstdc++ \
-    && apk add --no-cache --virtual .build-deps-full curl
+RUN apk add --no-cache libstdc++
 
 RUN echo "$NODE_URL"
-RUN curl -sSL "$NODE_URL" | tar -xz -C /usr/local/ && mv "$DIR_NODE/node-v${NODE_VERSION}-linux-x64" "$DIR_NODE/v$NODE_VERSION"
+RUN wget -O - "$NODE_URL" | tar -xz -C "$DIR_NODE" && \
+    mv "$DIR_NODE/node-v${NODE_VERSION}-linux-x64" "$DIR_NODE/v$NODE_VERSION"
 
 # add node and npm to path so that the commands are available
 ENV NODE_PATH $DIR_NODE/v$NODE_VERSION/lib/node_modules
 ENV PATH $DIR_NODE/v$NODE_VERSION/bin:$PATH
-
-# Clean up
-RUN apk del .build-deps-full
 
 # confirm installation
 RUN node -v


### PR DESCRIPTION
* Use `ARG` instead of `ENV` for build-only variables.
  
  I cannot see any reason why these variables need to be available within the container after build. As per [the documentation](https://docs.docker.com/engine/reference/builder/#env):
  
  > The environment variables set using `ENV` will persist when a container is run from the resulting image.
  > 
  > If an environment variable is only needed during build, and not in the final image, consider <i>[…]</i> using `ARG`, which is not persisted in the final image
  
  I.e. `NODE_VERSION` and `NODE_URL` will be available globally to all processes if we use `ENV`.
  
* Use BusyBox wget instead of separate curl.
  
  Speaks for itself. Instead of installing curl, we can depend on the already available wget. For me this shaved off almost another 5MB, as the 5th container layer shrank and the 10th container layer for cleanup can be removed entirely.

I also experimented with using `ADD` to download the archive file. Then the downloading would be handled by Docker and no internal dependency would be required at all. It would also add [the extra security of a checksum](https://docs.docker.com/engine/reference/builder/#verifying-a-remote-file-checksum-add---checksumchecksum-http-src-dest).

But because this would have to live in a separate layer from the unarchiving command, it grew the container size. This might still be an option if we [switch to multi-stage builds](https://docs.docker.com/build/building/multi-stage/).